### PR TITLE
Minimal changes needed to detect cold staking cold addresses

### DIFF
--- a/AddressOwnershipTool/Commands/Claim/ClaimInstruction.cs
+++ b/AddressOwnershipTool/Commands/Claim/ClaimInstruction.cs
@@ -29,6 +29,9 @@ public class ClaimInstruction : BaseInstruction
     [Option('p', "privkeyfile", Required = false, HelpText = "Please provide private key file, if used all other settings not required.")]
     public string PrivateKeyFile { get; set; }
 
+    [Option('z', "deep", Required = false, HelpText = "Perform deep scan. Generally only needed if cold staking addresses need to be included")]
+    public bool Deep { get; set; }
+
     public ClaimCommand ToCommand()
     {
         return new ClaimCommand
@@ -38,6 +41,7 @@ public class ClaimInstruction : BaseInstruction
             WalletName = WalletName,
             Testnet = Testnet,
             PrivateKeyFile = PrivateKeyFile,
+            Deep = Deep,
             UseCirrus = UseCirrus,
             Destination = Destination,
             DataFolder = DataFolder,

--- a/AddressOwnershipTool/Common/AddressOwnershipService.cs
+++ b/AddressOwnershipTool/Common/AddressOwnershipService.cs
@@ -300,7 +300,7 @@ public class AddressOwnershipService : IAddressOwnershipService
 
     public void HdAddressExport(Wallet wallet, string walletPassword, string destinationAddress, bool deepExport = false)
     {
-        foreach (HdAddress address in wallet.GetAllAddresses())
+        foreach (HdAddress address in wallet.GetAllAddresses(Wallet.AllAccounts))
         {
             if (address.Transactions.Count == 0 && !deepExport)
                 continue;


### PR DESCRIPTION
In lieu of a more complicated API-based approach, the user only needs the wallet database file to be accessible & can use a deep scan if the default run does not find the cold staking address(es) due to them having zero transactions.